### PR TITLE
Remove no-use-before-declare rule

### DIFF
--- a/packages/linters/tslint/bases/base.tslint.json
+++ b/packages/linters/tslint/bases/base.tslint.json
@@ -33,7 +33,6 @@
         "no-string-literal": false,
         "no-switch-case-fall-through": true,
         "no-unused-expression": true,
-        "no-use-before-declare": true,
         "no-var-keyword": true,
         "no-consecutive-blank-lines": [true, 2],
         "one-variable-per-declaration": true,


### PR DESCRIPTION
С TypeScript версии 2.9 правило `no-use-before-declare` является устаревшим. Вместо него предлагается использовать проверки компилятора. Предлагаю удалить его из конфига, чтобы не засорять консоль.