### PR TITLE
VSCode ext legacy field

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,19 +206,9 @@ Example of `tslint.json` file in your project:
 
 ## VS Code
 
-To make eslint work with `.ts` files:
+Eslint work with `.ts` files "out-of-the-box", just install extension:
 
 -   Install [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
--   [Find VSCode's settings file](https://code.visualstudio.com/docs/getstarted/settings#_settings-file-locations)
--   Add following to settings:
-    ```json
-    "eslint.validate": [
-        "javascript",
-        "javascriptreact",
-        "typescript",
-        "typescriptreact"
-    ]
-    ```
 
 ## Troubleshooting
 


### PR DESCRIPTION
Это легаси поле, теперь свойство называется `eslint.probe` и по умолчанию поддерживает `["javascript", "javascriptreact", "typescript", "typescriptreact", "html", "vue"]`

так что ТС там уже включен

https://github.com/Microsoft/vscode-eslint#settings-options