### PR TITLE
fix(eslint-plugin) replace interface-name-prefix

### DIFF
--- a/packages/linters/eslint/common/conventions.js
+++ b/packages/linters/eslint/common/conventions.js
@@ -37,6 +37,14 @@ module.exports = {
                 leadingUnderscore: 'require',
             },
             {
+                selector: 'interface',
+                format: ['PascalCase'],
+                custom: {
+                    regex: '^_?I[A-Z]',
+                    match: false,
+                },
+            },
+            {
                 selector: 'typeLike',
                 format: ['PascalCase'],
             },

--- a/packages/linters/eslint/common/typescript/conventions.js
+++ b/packages/linters/eslint/common/typescript/conventions.js
@@ -17,11 +17,11 @@ module.exports = tsOnly({
         '@typescript-eslint/naming-convention': [
             breaking({since: 2}),
             {
-                "selector": "interface",
-                "format": ["PascalCase"],
-                "custom": {
-                    "regex": "^I[A-Z]",
-                    "match": false
+                selector: 'interface',
+                format: ['PascalCase'],
+                custom: {
+                    regex: '^I[A-Z]',
+                    match: false,
                 },
             },
         ],

--- a/packages/linters/eslint/common/typescript/conventions.js
+++ b/packages/linters/eslint/common/typescript/conventions.js
@@ -14,9 +14,16 @@ module.exports = tsOnly({
                 caughtErrors: 'none',
             },
         ],
-        '@typescript-eslint/interface-name-prefix': [
+        '@typescript-eslint/naming-convention': [
             breaking({since: 2}),
-            {prefixWithI: 'never'},
+            {
+                "selector": "interface",
+                "format": ["PascalCase"],
+                "custom": {
+                    "regex": "^I[A-Z]",
+                    "match": false
+                },
+            },
         ],
 
         '@typescript-eslint/no-inferrable-types': [

--- a/packages/linters/eslint/common/typescript/conventions.js
+++ b/packages/linters/eslint/common/typescript/conventions.js
@@ -14,18 +14,6 @@ module.exports = tsOnly({
                 caughtErrors: 'none',
             },
         ],
-        '@typescript-eslint/naming-convention': [
-            breaking({since: 2}),
-            {
-                selector: 'interface',
-                format: ['PascalCase'],
-                custom: {
-                    regex: '^I[A-Z]',
-                    match: false,
-                },
-            },
-        ],
-
         '@typescript-eslint/no-inferrable-types': [
             'error',
             {


### PR DESCRIPTION
In typescript-eslint 3.0.0 interface-name-prefix was replaced by naming-convention ([see release notes](https://github.com/typescript-eslint/typescript-eslint/releases/tag/v3.0.0))
Implementation for replacement is taken from naming-convention examples: https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/naming-convention.md#enforce-that-interface-names-do-not-begin-with-an-i