### PR TITLE
Added compatibility with React 17

### DIFF
--- a/packages/eslint-config-react/index.js
+++ b/packages/eslint-config-react/index.js
@@ -104,6 +104,10 @@ module.exports = {
         'react-hooks/rules-of-hooks': 'error',
         'react-hooks/exhaustive-deps': 'error',
 
+        // For React 16 this rule have been enable. Because in old code we have import React
+        'react/jsx-uses-react': 'error',
+        'react/react-in-jsx-scope': 'off',
+
         'jsx-a11y/aria-role': 'warn',
         'jsx-a11y/no-static-element-interactions': 'warn',
         'jsx-a11y/anchor-has-content': 'warn',


### PR DESCRIPTION
In react 17 have new feature which conflict with this rules https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#eslint . For this reason i off rules