### PR TITLE
docs: update CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,6 @@
 ## Development
 
+-   Install [Lerna](https://github.com/lerna/lerna#readme) with `npm i -g lerna`.
 -   Intall deps with `npm run bootstrap`.
 -   Run tests with `npm run test:ci`.
 -   Follow [Conventional Commits specification](https://conventionalcommits.org/) for every commitmessage.


### PR DESCRIPTION
`npm run bootstrap` does not work without installed `lerna`. I think it's worth mentioning to prevent confusion.