### PR TITLE
fix: migrate from babel-eslint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,24 @@
 				"source-map": "^0.5.0"
 			}
 		},
+		"@babel/eslint-parser": {
+			"version": "7.14.7",
+			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.14.7.tgz",
+			"integrity": "sha512-6WPwZqO5priAGIwV6msJcdc9TsEPzYeYdS/Xuoap+/ihkgN6dzHp2bcAAwyWZ5bLzk0vvjDmKvRwkqNaiJ8BiQ==",
+			"requires": {
+				"eslint-scope": "^5.1.1",
+				"eslint-visitor-keys": "^2.1.0",
+				"semver": "^6.3.0"
+			}
+		},
+		"@babel/eslint-plugin": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/eslint-plugin/-/eslint-plugin-7.14.5.tgz",
+			"integrity": "sha512-nzt/YMnOOIRikvSn2hk9+W2omgJBy6U8TN0R+WTTmqapA+HnZTuviZaketdTE9W7/k/+E/DfZlt1ey1NSE39pg==",
+			"requires": {
+				"eslint-rule-composer": "^0.3.0"
+			}
+		},
 		"@babel/generator": {
 			"version": "7.14.5",
 			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.5.tgz",
@@ -3621,15 +3639,15 @@
 			"version": "file:packages/eslint-config",
 			"dev": true,
 			"requires": {
+				"@babel/eslint-parser": "^7.14.7",
+				"@babel/eslint-plugin": "^7.14.5",
 				"@typescript-eslint/eslint-plugin": "4.28.2",
 				"@typescript-eslint/parser": "4.28.2",
-				"babel-eslint": "^10.1.0",
 				"eslint": "^7.5.0",
 				"eslint-config-airbnb-base": "^14.2.0",
 				"eslint-config-prettier": "^6.11.0",
 				"eslint-import-resolver-typescript": "^2.0.0",
 				"eslint-import-resolver-webpack": "^0.12.2",
-				"eslint-plugin-babel": "^5.3.1",
 				"eslint-plugin-eslint-comments": "^3.2.0",
 				"eslint-plugin-import": "^2.22.0",
 				"eslint-plugin-jest": "^23.18.0",
@@ -4411,26 +4429,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
 			"integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA=="
-		},
-		"babel-eslint": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
-			"integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
-			"requires": {
-				"@babel/code-frame": "^7.0.0",
-				"@babel/parser": "^7.7.0",
-				"@babel/traverse": "^7.7.0",
-				"@babel/types": "^7.7.0",
-				"eslint-visitor-keys": "^1.0.0",
-				"resolve": "^1.12.0"
-			},
-			"dependencies": {
-				"eslint-visitor-keys": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-					"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ=="
-				}
-			}
 		},
 		"babel-jest": {
 			"version": "26.6.3",
@@ -7379,14 +7377,6 @@
 						"ms": "^2.1.1"
 					}
 				}
-			}
-		},
-		"eslint-plugin-babel": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-babel/-/eslint-plugin-babel-5.3.1.tgz",
-			"integrity": "sha512-VsQEr6NH3dj664+EyxJwO4FCYm/00JhYb3Sk3ft8o+fpKuIfQ9TaW6uVUfvwMXHcf/lsnRIoyFPsLMyiWCSL/g==",
-			"requires": {
-				"eslint-rule-composer": "^0.3.0"
 			}
 		},
 		"eslint-plugin-eslint-comments": {

--- a/packages/eslint-config/internal/base.js
+++ b/packages/eslint-config/internal/base.js
@@ -1,13 +1,13 @@
 module.exports = {
     extends: ['eslint-config-airbnb-base', 'plugin:eslint-comments/recommended'],
 
-    parser: 'babel-eslint',
+    parser: '@babel/eslint-parser',
 
     settings: {
-        'import/parser': 'babel-eslint',
+        'import/parser': '@babel/eslint-parser',
     },
 
-    plugins: ['babel'],
+    plugins: ['@babel'],
 
     parserOptions: {
         ecmaFeatures: {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -3,11 +3,7 @@
     "version": "1.2.0",
     "description": "Tinkoff ESLint configs to rule them all",
     "license": "Apache-2.0",
-    "keywords": [
-        "eslint",
-        "eslintconfig",
-        "eslint-config"
-    ],
+    "keywords": ["eslint", "eslintconfig", "eslint-config"],
     "scripts": {},
     "main": "index.js",
     "author": {
@@ -19,15 +15,15 @@
         "url": "https://github.com/TinkoffCreditSystems/linters.git"
     },
     "dependencies": {
+        "@babel/eslint-parser": "^7.14.7",
+        "@babel/eslint-plugin": "^7.14.5",
         "@typescript-eslint/eslint-plugin": "4.28.2",
         "@typescript-eslint/parser": "4.28.2",
-        "babel-eslint": "^10.1.0",
         "eslint": "^7.5.0",
         "eslint-config-airbnb-base": "^14.2.0",
         "eslint-config-prettier": "^6.11.0",
         "eslint-import-resolver-typescript": "^2.0.0",
         "eslint-import-resolver-webpack": "^0.12.2",
-        "eslint-plugin-babel": "^5.3.1",
         "eslint-plugin-eslint-comments": "^3.2.0",
         "eslint-plugin-import": "^2.22.0",
         "eslint-plugin-jest": "^23.18.0",


### PR DESCRIPTION
babel-eslint is deprecated now:  [`babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.`](https://www.npmjs.com/package/babel-eslint)

migrated by https://babeljs.io/blog/2020/07/13/the-state-of-babel-eslint#the-future