### PR TITLE
enable rule @typescript-eslint/no-unused-vars

### DIFF
--- a/packages/eslint-config/internal/typescript.js
+++ b/packages/eslint-config/internal/typescript.js
@@ -19,7 +19,14 @@ module.exports = {
                 // swears on cases like constructor(public c: C) {}
                 'no-useless-constructor': 'off',
                 '@typescript-eslint/explicit-function-return-type': 'off',
-                '@typescript-eslint/no-unused-vars': 'off',
+                'no-unused-vars': 'off',
+                '@typescript-eslint/no-unused-vars': [
+                    'warn',
+                    {
+                        argsIgnorePattern: '^_',
+                        varsIgnorePattern: '^_',
+                    },
+                ],
                 'class-methods-use-this': 'off',
                 '@typescript-eslint/member-ordering': [
                     'off',


### PR DESCRIPTION
Unused variables can be marked with underscores. This can be useful for creating copies of an object with the removal of certain properties through destructuring.

eg:
```
const {
    alert: _unused,
    ...windowWithoutAlert
} = window;
```