### PR TITLE
feat: remove react-perf plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7666,11 +7666,6 @@
 			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz",
 			"integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ=="
 		},
-		"eslint-plugin-react-perf": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react-perf/-/eslint-plugin-react-perf-3.3.0.tgz",
-			"integrity": "sha512-POzjKFOuHpyGZFwLkqPK8kxLy/tYVeq30h+SEM1UwfSmkyPcbEjbbGw1gN5R1hxCHf4zJ0G0NIbY+oCe8i/DNQ=="
-		},
 		"eslint-plugin-sort-class-members": {
 			"version": "1.11.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-sort-class-members/-/eslint-plugin-sort-class-members-1.11.0.tgz",

--- a/packages/eslint-config-react/index.js
+++ b/packages/eslint-config-react/index.js
@@ -26,7 +26,7 @@ module.exports = {
         browser: true,
     },
 
-    plugins: ['react', 'react-hooks', 'react-perf'],
+    plugins: ['react', 'react-hooks'],
 
     overrides: [
         {
@@ -34,16 +34,6 @@ module.exports = {
 
             rules: {
                 'react/prop-types': 'off',
-            },
-        },
-        {
-            files: ['*.spec.*', '*.test.*', '*.unit.*', '*/__tests__/*'],
-
-            rules: {
-                'react-perf/jsx-no-new-object-as-prop': 'off',
-                'react-perf/jsx-no-new-array-as-prop': 'off',
-                'react-perf/jsx-no-new-function-as-prop': 'off',
-                'react-perf/jsx-no-jsx-as-prop': 'off',
             },
         },
     ],
@@ -136,10 +126,5 @@ module.exports = {
         'class-methods-use-this': 'off',
         'react/jsx-props-no-spreading': 'warn',
         'no-underscore-dangle': 'off',
-
-        'react-perf/jsx-no-new-object-as-prop': 'warn',
-        'react-perf/jsx-no-new-array-as-prop': 'warn',
-        'react-perf/jsx-no-new-function-as-prop': 'warn',
-        'react-perf/jsx-no-jsx-as-prop': 'warn',
     },
 };

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -3,11 +3,7 @@
     "version": "1.2.4",
     "description": "Tinkoff ESLint configs for React apps",
     "license": "Apache-2.0",
-    "keywords": [
-        "eslint",
-        "eslintconfig",
-        "eslint-config"
-    ],
+    "keywords": ["eslint", "eslintconfig", "eslint-config"],
     "scripts": {},
     "main": "index.js",
     "author": {
@@ -22,8 +18,7 @@
         "eslint-config-airbnb": "^18.2.0",
         "eslint-plugin-jsx-a11y": "^6.3.1",
         "eslint-plugin-react": "^7.20.3",
-        "eslint-plugin-react-hooks": "^4.0.8",
-        "eslint-plugin-react-perf": "^3.3.0"
+        "eslint-plugin-react-hooks": "^4.0.8"
     },
     "devDependencies": {
         "@tinkoff/eslint-config": "^1.2.4"


### PR DESCRIPTION
**Мотивация**

Хочется уменьшить количество warning, которые засоряют вывод консоли. Отсюда два выхода: Поднять строгость правил до error, либо убрать правило. Конфигурировать правила более тонко пакет react-perf не позволяет. 

Почему предлагаю убрать? 
Правила из пакета react-perf полезные, но не универсальные - нередки ситуации, когда дополнительная мемоизация бывает излишней. В текущей ситуации это приводит к тому, что растет количество ошибок уровня warning в консоли.