### PR TITLE
fix:  rule react/jsx-props-no-spreading removed from react config

### DIFF
--- a/packages/eslint-config-react/index.js
+++ b/packages/eslint-config-react/index.js
@@ -124,7 +124,7 @@ module.exports = {
         'jsx-a11y/click-events-have-key-events': 'warn',
         'jsx-a11y/mouse-events-have-key-events': 'warn',
         'class-methods-use-this': 'off',
-        'react/jsx-props-no-spreading': 'warn',
+        'react/jsx-props-no-spreading': 'off',
         'no-underscore-dangle': 'off',
     },
 };


### PR DESCRIPTION
**Мотивация**

Правило не универсальное, иногда спрединг пропсов это стандартая практика, напрмер при разработке UI компонентов. 