### PR TITLE
fix(prettier-config): support autoload plugins, support vscode

### DIFF
--- a/packages/prettier-config/angular.js
+++ b/packages/prettier-config/angular.js
@@ -10,8 +10,13 @@ module.exports = {
   trailingComma: 'all',
   bracketSpacing: false,
   arrowParens: 'avoid',
-  plugins: ['prettier-plugin-organize-attributes', '@prettier/plugin-xml'],
+  plugins: [
+    // https://github.com/prettier/prettier-vscode/issues/2259#issuecomment-952950119
+    require.resolve('prettier-plugin-organize-attributes'),
+    require.resolve('@prettier/plugin-xml'),
+  ],
   attributeGroups: [
+    // prettier-plugin-organize-attribute
     '$ANGULAR_STRUCTURAL_DIRECTIVE',
     '$ANGULAR_ELEMENT_REF',
     '$ID',
@@ -57,6 +62,7 @@ module.exports = {
       options: { parser: 'xml' },
     },
     {
+      // @prettier/plugin-xml
       files: ['*.xml'],
       options: { parser: 'xml' },
     },


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

VScode breaks

```
["INFO" - 3:43:26 PM] Formatting file:///Users/e.kursakov/Projects/design-tokens/android/tokens-build/platform-android.ts
["INFO" - 3:43:26 PM] Using config file at '/Users/e.kursakov/Projects/design-tokens/.prettierrc.js'
["INFO" - 3:43:26 PM] Using ignore file (if present) at /Users/e.kursakov/Projects/design-tokens/.prettierignore
["INFO" - 3:43:26 PM] File Info:
{
  "ignored": false,
  "inferredParser": "typescript"
}
["INFO" - 3:43:26 PM] Detected local configuration (i.e. .prettierrc or .editorconfig), VS Code configuration will not be used
["INFO" - 3:43:26 PM] Prettier Options:
{
  "filepath": "/Users/e.kursakov/Projects/design-tokens/android/tokens-build/platform-android.ts",
  "parser": "typescript",
  "tabWidth": 4,
  "singleQuote": true,
  "trailingComma": "none",
  "arrowParens": "avoid",
  "htmlWhitespaceSensitivity": "ignore",
  "printWidth": 120,
  "proseWrap": "always",
  "useTabs": false,
  "semi": true,
  "bracketSpacing": true,
  "plugins": [
    "prettier-plugin-organize-attributes",
    "@prettier/plugin-xml"
  ],
  "attributeGroups": [
    "$ANGULAR_STRUCTURAL_DIRECTIVE",
    "$ANGULAR_ELEMENT_REF",
    "$ID",
    "$DEFAULT",
    "$CLASS",
    "$ANGULAR_ANIMATION",
    "$ANGULAR_ANIMATION_INPUT",
    "$ANGULAR_INPUT",
    "$ANGULAR_TWO_WAY_BINDING",
    "$ANGULAR_OUTPUT"
  ]
}
["ERROR" - 3:43:26 PM] Error formatting document.
["ERROR" - 3:43:26 PM] Cannot find module 'prettier-plugin-organize-attributes'
Require stack:
- /Users/e.kursakov/Projects/design-tokens/node_modules/prettier/index.js
- /Users/e.kursakov/.vscode/extensions/esbenp.prettier-vscode-9.0.0/dist/extension.js
- /Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/loader.js
- /Applications/Visual Studio Code.app/Contents/Resources/app/out/bootstrap-amd.js
- /Applications/Visual Studio Code.app/Contents/Resources/app/out/bootstrap-fork.js
Error: Cannot find module 'prettier-plugin-organize-attributes'
Require stack:
- /Users/e.kursakov/Projects/design-tokens/node_modules/prettier/index.js
- /Users/e.kursakov/.vscode/extensions/esbenp.prettier-vscode-9.0.0/dist/extension.js
- /Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/loader.js
- /Applications/Visual Studio Code.app/Contents/Resources/app/out/bootstrap-amd.js
- /Applications/Visual Studio Code.app/Contents/Resources/app/out/bootstrap-fork.js
	at Function.Module._resolveFilename (internal/modules/cjs/loader.js:934:15)
	at h.resolve (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/loader.js:4:761)
	at /Users/e.kursakov/Projects/design-tokens/node_modules/prettier/index.js:59236:21
	at Array.map (<anonymous>)
	at Object.load (/Users/e.kursakov/Projects/design-tokens/node_modules/prettier/index.js:59228:61)
	at Object.load [as loadPlugins] (/Users/e.kursakov/Projects/design-tokens/node_modules/prettier/index.js:15770:23)
	at /Users/e.kursakov/Projects/design-tokens/node_modules/prettier/index.js:59302:28
	at Object.format (/Users/e.kursakov/Projects/design-tokens/node_modules/prettier/index.js:59324:12)
	at t.default.<anonymous> (/Users/e.kursakov/.vscode/extensions/esbenp.prettier-vscode-9.0.0/dist/extension.js:1:14671)
	at Generator.next (<anonymous>)
	at s (/Users/e.kursakov/.vscode/extensions/esbenp.prettier-vscode-9.0.0/dist/extension.js:1:7872)
["INFO" - 3:43:26 PM] Formatting completed in 0.005ms.
```

## What is the new behavior?

Prettier expects each of pluginSearchDirs to contain node_modules subdirectory, where @prettier/plugin-*, @*/prettier-plugin-* and prettier-plugin-* will be searched. For instance, this can be your project directory or the location of global npm modules.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
